### PR TITLE
Unpin `databroker` dependency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/event-model @kbeeperez @mrakitin @sbillinge @st3107
+* @conda-forge/event-model @mrakitin @sbillinge @st3107

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Feedstock Maintainers
 =====================
 
 * [@conda-forge/event-model](https://github.com/conda-forge/event-model/)
-* [@kbeeperez](https://github.com/kbeeperez/)
 * [@mrakitin](https://github.com/mrakitin/)
 * [@sbillinge](https://github.com/sbillinge/)
 * [@st3107](https://github.com/st3107/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - run_server = pdfstream.main:run_server
     - print_server_config_dir = pdfstream.main:print_server_config_dir
   script: {{ PYTHON }} -m pip install . -vv --no-deps
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -25,7 +25,7 @@ requirements:
   run:
     - python >=3.8, <3.10
     - bluesky
-    - databroker <2.0.0a
+    - databroker
     - fire
     - frozendict
     - numba
@@ -43,13 +43,11 @@ about:
   home: https://github.com/xpdAcq/pdfstream
   summary: The data analysis toolbox for the study on pair distribution function (PDF).
   license: BSD-3-Clause
-  license_file:
-    - LICENSE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - sbillinge
     - st3107
     - mrakitin
-    - kbeeperez
     - conda-forge/event-model


### PR DESCRIPTION
This PR unpins `databroker` dependency as `pdfstream` is supposed to work now with both versions of `databroker` (1.2.5 and 2.0.0b*)
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
